### PR TITLE
Update rook url

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ My cluster is [k3s](https://k3s.io/) provisioned overtop bare-metal Ubuntu 20.04
 ### Core Components
 
 - [projectcalico/calico](https://github.com/projectcalico/calico): Internal Kubernetes networking plugin.
-- [rook/rook](https://github.com/projectcalico/calico): Distributed block storage for peristent storage.
+- [rook/rook](https://github.com/rook/rook): Distributed block storage for peristent storage.
 - [mozilla/sops](https://toolkit.fluxcd.io/guides/mozilla-sops/): Manages secrets for Kubernetes, Ansible and Terraform.
 - [kubernetes-sigs/external-dns](https://github.com/kubernetes-sigs/external-dns): Automatically manages DNS records from my cluster in a cloud DNS provider.
 - [jetstack/cert-manager](https://cert-manager.io/docs/): Creates SSL certificates for services in my Kubernetes cluster.


### PR DESCRIPTION
**Description of the change**
Currently under Core Components rook/rook links to projectcalico/calico which is obvious not the correct place.

**Benefits**
Correct readme that might benefit other people

**Possible drawbacks**

**Applicable issues**

- fixes #

**Additional information**

offtopic: Really helpful repo and keep up the awesome work!
