### PR TITLE
feat(monitoring): read kromgo from Mimir via OAuth2 auth proxy

### DIFF
--- a/kubernetes/apps/monitoring/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kromgo/app/helmrelease.yaml
@@ -11,7 +11,10 @@ spec:
   interval: 1h
   values:
     config:
-      prometheus: http://prometheus-operated.monitoring.svc.cluster.local:9090
+      # Mimir's Prometheus-compatible query API, via the mimir-proxy sidecar
+      # Deployment which injects the OAuth2 (client_credentials) bearer token for
+      # mimir.cloud.witl.xyz. kromgo's Prometheus client cannot do OAuth2 itself.
+      prometheus: http://mimir-proxy.monitoring.svc.cluster.local:8080/prometheus
       badges:
         - title: Talos
           id: talos_version

--- a/kubernetes/apps/monitoring/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kustomization.yaml
@@ -16,5 +16,6 @@ resources:
   - ./kromgo/ks.yaml
   - ./kube-prometheus-stack/ks.yaml
   - ./loki/ks.yaml
+  - ./mimir-proxy/ks.yaml
   - ./smartctl-exporter/ks.yaml
   - ./unpoller/ks.yaml

--- a/kubernetes/apps/monitoring/mimir-proxy/app/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/mimir-proxy/app/externalsecret.yaml
@@ -1,0 +1,161 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mimir-proxy
+spec:
+  # The rendered Envoy bootstrap embeds the OAuth2 client_id/client_secret, so it
+  # is materialised as a Secret rather than a ConfigMap. Reuses the same 1Password
+  # item ("observability-m2m") that k8s-monitoring / Alloy use for Mimir writes.
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: mimir-proxy-secret
+    template:
+      engineVersion: v2
+      data:
+        bootstrap.yaml: |
+          node:
+            id: mimir-proxy
+            cluster: mimir-proxy
+
+          admin:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 9901
+
+          static_resources:
+            secrets:
+              - name: mimir_client_secret
+                generic_secret:
+                  secret:
+                    inline_string: "{{ trim .client_secret }}"
+
+            listeners:
+              - name: proxy
+                address:
+                  socket_address:
+                    address: 0.0.0.0
+                    port_value: 8080
+                filter_chains:
+                  - filters:
+                      - name: envoy.filters.network.http_connection_manager
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                          stat_prefix: mimir_proxy
+                          http_filters:
+                            - name: envoy.filters.http.credential_injector
+                              typed_config:
+                                "@type": type.googleapis.com/envoy.extensions.filters.http.credential_injector.v3.CredentialInjector
+                                overwrite: true
+                                allow_request_without_credential: false
+                                credential:
+                                  name: envoy.http.injected_credentials.oauth2
+                                  typed_config:
+                                    "@type": type.googleapis.com/envoy.extensions.http.injected_credentials.oauth2.v3.OAuth2
+                                    token_endpoint:
+                                      cluster: authentik
+                                      uri: https://auth.cloud.witl.xyz/application/o/token/
+                                      timeout: 10s
+                                    scopes:
+                                      - "openid"
+                                      - "tenant"
+                                      - "mimir:read"
+                                    client_credentials:
+                                      client_id: "{{ trim .client_id }}"
+                                      client_secret:
+                                        name: mimir_client_secret
+                            - name: envoy.filters.http.router
+                              typed_config:
+                                "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                          route_config:
+                            name: mimir
+                            virtual_hosts:
+                              - name: mimir
+                                domains: ["*"]
+                                routes:
+                                  - match:
+                                      prefix: /
+                                    route:
+                                      cluster: mimir_cloud
+                                      timeout: 45s
+                                      host_rewrite_literal: mimir.cloud.witl.xyz
+              - name: health
+                address:
+                  socket_address:
+                    address: 0.0.0.0
+                    port_value: 9902
+                filter_chains:
+                  - filters:
+                      - name: envoy.filters.network.http_connection_manager
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                          stat_prefix: health
+                          http_filters:
+                            - name: envoy.filters.http.router
+                              typed_config:
+                                "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                          route_config:
+                            name: health
+                            virtual_hosts:
+                              - name: health
+                                domains: ["*"]
+                                routes:
+                                  - match:
+                                      path: /healthz
+                                    direct_response:
+                                      status: 200
+                                      body:
+                                        inline_string: OK
+
+            clusters:
+              - name: mimir_cloud
+                type: LOGICAL_DNS
+                connect_timeout: 10s
+                dns_lookup_family: V4_PREFERRED
+                load_assignment:
+                  cluster_name: mimir_cloud
+                  endpoints:
+                    - lb_endpoints:
+                        - endpoint:
+                            address:
+                              socket_address:
+                                address: mimir.cloud.witl.xyz
+                                port_value: 443
+                transport_socket:
+                  name: envoy.transport_sockets.tls
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+                    sni: mimir.cloud.witl.xyz
+                    common_tls_context:
+                      validation_context:
+                        trusted_ca:
+                          filename: /etc/ssl/certs/ca-certificates.crt
+              - name: authentik
+                type: LOGICAL_DNS
+                connect_timeout: 10s
+                dns_lookup_family: V4_PREFERRED
+                load_assignment:
+                  cluster_name: authentik
+                  endpoints:
+                    - lb_endpoints:
+                        - endpoint:
+                            address:
+                              socket_address:
+                                address: auth.cloud.witl.xyz
+                                port_value: 443
+                transport_socket:
+                  name: envoy.transport_sockets.tls
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+                    sni: auth.cloud.witl.xyz
+                    common_tls_context:
+                      validation_context:
+                        trusted_ca:
+                          filename: /etc/ssl/certs/ca-certificates.crt
+  dataFrom:
+    - extract:
+        key: observability-m2m

--- a/kubernetes/apps/monitoring/mimir-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/mimir-proxy/app/helmrelease.yaml
@@ -1,0 +1,93 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: mimir-proxy
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: mimir-proxy
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      mimir-proxy:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: mirror.gcr.io/envoyproxy/envoy
+              tag: v1.39.1
+              pullPolicy: IfNotPresent
+            args:
+              - -c
+              - /etc/envoy/bootstrap.yaml
+              - --service-cluster
+              - mimir-proxy
+              - --service-node
+              - mimir-proxy
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 9902
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 2
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 9902
+                  initialDelaySeconds: 2
+                  periodSeconds: 3
+                  failureThreshold: 30
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 10m
+                memory: 48Mi
+              limits:
+                memory: 128Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        ports:
+          http:
+            port: 8080
+            primary: true
+    persistence:
+      bootstrap:
+        type: secret
+        name: mimir-proxy-secret
+        globalMounts:
+          - path: /etc/envoy
+            readOnly: true
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/monitoring/mimir-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/mimir-proxy/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/monitoring/mimir-proxy/app/ocirepository.yaml
+++ b/kubernetes/apps/monitoring/mimir-proxy/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: mimir-proxy
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/monitoring/mimir-proxy/ks.yaml
+++ b/kubernetes/apps/monitoring/mimir-proxy/ks.yaml
@@ -3,12 +3,10 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: kromgo
+  name: mimir-proxy
 spec:
   interval: 1h
-  dependsOn:
-    - name: mimir-proxy
-  path: ./kubernetes/apps/monitoring/kromgo/app
+  path: ./kubernetes/apps/monitoring/mimir-proxy/app
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
kromgo pointed at prometheus-operated.monitoring.svc.cluster.local:9090, which no longer exists (kube-prometheus-stack runs rules/dashboards only). Metrics live in the external mimir.cloud.witl.xyz behind Authentik M2M OAuth2, and kromgo's Prometheus client cannot do OAuth2 or custom headers.

Add mimir-proxy: an Envoy Deployment (app-template) that proxies to mimir.cloud.witl.xyz and injects an OAuth2 client_credentials bearer token via the credential_injector + injected_credentials.oauth2 filter. The full Envoy bootstrap is rendered by the ExternalSecret template so the client_id/client_secret from the observability-m2m 1Password item stay in a Secret rather than a ConfigMap; stakater reloader restarts on rotation.

Point kromgo at http://mimir-proxy.monitoring.svc.cluster.local:8080/prometheus and add a dependsOn.

Claude-Session: https://claude.ai/code/session_01TTERrm67Cz243bosUe425L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a secure proxy for connecting monitoring data to the Mimir cloud service.
  * Enabled Kromgo to retrieve Prometheus data through the Mimir-backed endpoint with authenticated access.
  * Added health monitoring and hardened deployment settings for the proxy.

* **Bug Fixes**
  * Ensured the proxy is deployed before Kromgo, preventing connectivity issues during reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->