### PR TITLE
fix(nfs-scaler): point KEDA prometheus trigger at mimir-proxy

### DIFF
--- a/kubernetes/components/nfs-scaler/scaledobject.yaml
+++ b/kubernetes/components/nfs-scaler/scaledobject.yaml
@@ -17,7 +17,8 @@ spec:
   triggers:
     - type: prometheus
       metadata:
-        serverAddress: http://mimir.monitoring.svc.cluster.local/prometheus
-        query: probe_success{instance=~".+:2049"}
+        # Cloud Mimir's query API via the mimir-proxy sidecar (handles OAuth2).
+        serverAddress: http://mimir-proxy.monitoring.svc.cluster.local:8080/prometheus
+        query: probe_success{cluster="kyak", instance=~".+:2049"}
         threshold: "1"
         ignoreNullValues: "0"


### PR DESCRIPTION
`http://mimir.monitoring.svc.cluster.local/prometheus` (orphaned, undeployed) → `http://mimir-proxy.monitoring.svc.cluster.local:8080/prometheus` (fronts cloud Mimir with OAuth2). Query scoped to `cluster="kyak"`.

Notes:
- `components/nfs-scaler` is not referenced by any kustomization (dead code); this just makes it correct if re-enabled.
- No `probe_success{instance=~".+:2049"}` series exists in Mimir yet — an NFS blackbox Probe is still needed before the ScaledObject can actually scale.
